### PR TITLE
Support forward/backward operations

### DIFF
--- a/pymtst/tape_drive.py
+++ b/pymtst/tape_drive.py
@@ -13,6 +13,8 @@ timeouts = {
     'rewind': 11 * 60,
     'eom': 49 * 60,
     'asf': 49 * 60,
+    'fsf': 49 * 60,
+    'bsfm': 49 * 60,
     'weof': 28 * 60,
     'erase': 14.8 * 60 * 60,
 }
@@ -120,6 +122,14 @@ class TapeDrive:
     @synchronized('_lock')
     def asf(self, count):
         self._execute_mt(["asf", str(count)])
+
+    @synchronized('_lock')
+    def fsf(self, count):
+        self._execute_mt(["fsf", str(count)])
+
+    @synchronized('_lock')
+    def bsfm(self, count):
+        self._execute_mt(["bsfm", str(count)])
 
     @synchronized('_lock')
     def erase(self, quickly=True):

--- a/tests/test_tape_drive.py
+++ b/tests/test_tape_drive.py
@@ -78,6 +78,29 @@ class TestTapeDrive(TestCase):
 
         self.assertIn("Input/output error", str(cm.exception.stderr))
 
+    def test_fsf(self):
+        subprocess.run(['mt-gnu', "-f", prop['device'], "rewind"], timeout=TIMEOUT, check=True)
+        self.d.fsf(1)
+        self.assertEqual(1, self.d.current_file_number())
+
+        subprocess.run(['mt-gnu', "-f", prop['device'], "eom"], timeout=TIMEOUT, check=True)
+
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.d.fsf(1)
+
+        self.assertIn("Input/output error", str(cm.exception.stderr))
+
+    def test_bsfm(self):
+        subprocess.run(['mt-gnu', "-f", prop['device'], "asf", "1"], timeout=TIMEOUT, check=True)
+
+        self.d.bsfm(1)
+        self.assertEqual(1, self.d.current_file_number())
+
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.d.bsfm(2)
+
+        self.assertIn("Input/output error", str(cm.exception.stderr))
+
     def test_erase(self):
         subprocess.run(['mt-gnu', "-f", prop['device'], "weof"], timeout=TIMEOUT, check=True)
         self.d.erase()


### PR DESCRIPTION
```
fsf    Forward space count files.  The tape is positioned on the first block of the next file.

bsfm   Backward  space count files, then forward space one record. This leaves the tape positioned at the
              first block of the file that is count - 1 files before the current file.
```